### PR TITLE
feat: Add info callout support

### DIFF
--- a/assets/templates/callouts.html
+++ b/assets/templates/callouts.html
@@ -1,0 +1,52 @@
+<style>
+.mdbook-obsidian-callouts {
+  padding: 8px 16px;
+  margin-bottom: 16px;
+  border-left: 0.25em solid var(--mdbook-obsidian-callouts-color);
+}
+
+.mdbook-obsidian-callouts>*:first-child {
+  margin-top: 0;
+}
+
+.mdbook-obsidian-callouts>*:last-child {
+  margin-bottom: 0;
+}
+
+.mdbook-obsidian-callouts-title {
+  display: flex;
+  font-weight: 600;
+  align-items: center;
+  line-height: 1;
+  color: var(--mdbook-obsidian-callouts-color);
+  text-transform: capitalize;
+}
+
+.mdbook-obsidian-callouts-icon {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  margin-right: 0.2em;
+  background-color: currentColor;
+  -webkit-mask: no-repeat center / 100%;
+  mask: no-repeat center / 100%;
+  -webkit-mask-image: var(--mdbook-obsidian-callouts-icon);
+  mask-image: var(--mdbook-obsidian-callouts-icon);
+}
+
+/* Icons from https://icon-sets.iconify.design/material-symbols */
+.mdbook-obsidian-callouts-info {
+  --mdbook-obsidian-callouts-color: rgb(9, 105, 218);
+  --mdbook-obsidian-callouts-icon: url('data:image/svg+xml,%3Csvg xmlns="http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg" width="24" height="24" viewBox="0 0 24 24"%3E%3Cpath fill="currentColor" d="M12 17q.425 0 .713-.288T13 16v-4q0-.425-.288-.712T12 11q-.425 0-.712.288T11 12v4q0 .425.288.713T12 17m0-8q.425 0 .713-.288T13 8q0-.425-.288-.712T12 7q-.425 0-.712.288T11 8q0 .425.288.713T12 9m0 13q-2.075 0-3.9-.788t-3.175-2.137q-1.35-1.35-2.137-3.175T2 12q0-2.075.788-3.9t2.137-3.175q1.35-1.35 3.175-2.137T12 2q2.075 0 3.9.788t3.175 2.137q1.35 1.35 2.138 3.175T22 12q0 2.075-.788 3.9t-2.137 3.175q-1.35 1.35-3.175 2.138T12 22m0-2q3.35 0 5.675-2.325T20 12q0-3.35-2.325-5.675T12 4Q8.65 4 6.325 6.325T4 12q0 3.35 2.325 5.675T12 20m0-8"%2F%3E%3C%2Fsvg%3E');
+}
+
+</style>
+<div class="mdbook-obsidian-callouts mdbook-obsidian-callouts-{kind}">
+  <p class="mdbook-obsidian-callouts-title">
+    <span class="mdbook-obsidian-callouts-icon"></span>
+    {kind}
+  </p>
+
+  {body}
+
+</div>

--- a/src/callouts.rs
+++ b/src/callouts.rs
@@ -1,0 +1,29 @@
+use super::Asset;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Uses regex to find [Obsidian callouts](https://help.obsidian.md/Editing+and+formatting/Callouts)
+/// and replaces them with appropriate HTML rendering
+pub fn render(content: &str) -> Result<String, mdbook::errors::Error> {
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        Regex::new(r"(?m)^> \[!(?P<kind>[^\]]+)\]\s*$(?P<body>(?:\n>.*)*)")
+            .expect("failed to parse regex")
+    });
+    let callouts = Asset::get("templates/callouts.html").expect("template not found");
+    let callouts = std::str::from_utf8(callouts.data.as_ref())?;
+    let content = RE.replace_all(content, |caps: &regex::Captures| {
+        let kind = caps
+            .name("kind")
+            .expect("kind not found in regex")
+            .as_str()
+            .to_lowercase();
+        let body = caps
+            .name("body")
+            .expect("body not found in regex")
+            .as_str()
+            .replace("\n>\n", "\n\n")
+            .replace("\n> ", "\n");
+        callouts.replace("{kind}", &kind).replace("{body}", &body)
+    });
+    Ok(content.into())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,13 @@ use mdbook::book::Book;
 use mdbook::book::{BookItem, Chapter};
 use mdbook::errors::Error;
 use mdbook::preprocess::{Preprocessor, PreprocessorContext};
+use rust_embed::RustEmbed;
+
+mod callouts;
+
+#[derive(RustEmbed)]
+#[folder = "assets/"]
+pub struct Asset;
 
 /// The Obsidian preprocessor.
 pub struct Obsidian;
@@ -45,7 +52,8 @@ impl Preprocessor for Obsidian {
 }
 
 /// Apply to all chapters
-fn handle_chapter(_chapter: &mut Chapter) -> Result<(), Error> {
+fn handle_chapter(chapter: &mut Chapter) -> Result<(), Error> {
+    chapter.content = callouts::render(&chapter.content)?;
     // Add your additional syntax parsing here
 
     Ok(())


### PR DESCRIPTION
Adds support for the `[!info]` callout in Obsidian syntax


Renders
```markdown
## Info

> [!info]
> For your information

> [!info] This is bold
> More information
```
as
![image](https://github.com/GeckoEidechse/mdbook-obsidian/assets/40122905/e14f6036-0c1d-4a71-916d-369efcf6ca74)

which is very much still incomplete but a good first start